### PR TITLE
Do not attempt to make plots responsive on new bokeh version

### DIFF
--- a/linkermapviz/__init__.py
+++ b/linkermapviz/__init__.py
@@ -165,7 +165,7 @@ def main ():
         p.legend.orientation = "horizontal"
 
         plots.append (p)
-    show (column (*plots, responsive=True))
+    show (column (*plots, sizing_mode="scale_width"))
 
 if __name__ == '__main__':
     main ()


### PR DESCRIPTION
According to https://github.com/bokeh/bokeh/issues/4620, the `responsive` parameter is not supported anymore.

An alternative to that commit would be to set `sizing_mode` as shown [here](https://github.com/kongr45gpen/linkermapviz/commit/ddeaba822f8824b6829e2db654c81c7e20e9044e), but that makes the graph take up the whole width of the window, and its height goes off the viewport, making it not very practical to use.